### PR TITLE
Update quartodoc workflow to run on main branch

### DIFF
--- a/.github/workflows/quartodoc.yml
+++ b/.github/workflows/quartodoc.yml
@@ -2,7 +2,7 @@ name: quartodoc
 
 on:
   push:
-    branches: [documentation]
+    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
Changed the GitHub Actions workflow trigger from the 'documentation' branch to 'main' to ensure documentation builds are triggered on main branch updates.

