### PR TITLE
Create preview.yml for Documentation Previews.

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,86 @@
+name: Preview Documentation
+
+on:
+  workflow_dispatch:
+  pull_request: # Intent is to generate netlify preview each time someone creates a PR only on dev.  
+    branch: [ development ]
+  
+
+jobs:
+  render-docs-preview-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      deployments: write
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[docs]"
+
+      - name: quartodoc build
+        run: |
+          quartodoc build
+
+      - name: Render Quarto Project
+        uses: quarto-dev/quarto-actions/render@v2
+
+      # =====================================================
+      # Deploy to Netlify
+      # =====================================================
+
+      # Create a unique name for this deployment using the PR number
+      # This helps track which PR preview is which
+      - name: Configure release name
+        run: echo "RELEASE_NAME=pr-${{ github.event.number }}" >> $GITHUB_ENV
+
+      # Create a deployment status on GitHub to track the deployment progress
+      # This shows up in the PR's "Deployments" section
+      - name: Create deployment status
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ env.RELEASE_NAME }}
+          ref: ${{ github.head_ref }}
+          logs: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+      # Deploy the rendered site to Netlify with a PR-specific preview URL
+      # The alias ensures each PR gets its own stable URL during review
+      - name: Deploy to Netlify
+        id: netlify
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        run: |
+          npm install -g netlify-cli
+          netlify deploy --dir=_site/ --alias="pr-${{ github.event.number }}" 2>&1 | tee deploy.log
+          DEPLOY_URL=$(grep -oP 'https://[^\s]+' deploy.log | grep -E '(netlify\.app|--.*\.netlify\.app)' | head -n 1)
+          echo "url=${DEPLOY_URL}" >> $GITHUB_OUTPUT
+          
+      # Update the GitHub deployment status with success/failure and the preview URL
+      # This creates a clickable link in the PR to view the deployed preview
+      - name: Update deployment status
+        uses: bobheadxi/deployments@v1
+        if: always()
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env: ${{ steps.deployment.outputs.env }}
+          env_url: ${{ steps.netlify.outputs.url }}
+          logs: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'


### PR DESCRIPTION
- [ ] fix #65 
- [ ] Create a preview.yml to deploy a docs website on Netlify for every PR created on the `development` branch. The intent is that for each feature created and subsequent PR on the `development` branch, a preview website is developed so development team can review the layout of the docs. This is only a preview, and the final document publishing through quarto will take place on pushes to the `main` branch. 
