### PR TITLE
Fix/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Beautiful Numbers is a small Python package that provides utilities for explorin
 Install the package from Test PyPI:
 
 ``` bash
-pip install --index-url https://test.pypi.org/simple/beautifulnumbers
+pip install -i https://test.pypi.org/simple/ beautifulnumbers
 ```
 
 **Package URL**: https://test.pypi.org/project/beautifulnumbers/


### PR DESCRIPTION
- fix #62 and #76
Replaces the long-form --index-url option with the short-form -i in the pip install 
